### PR TITLE
ИНН в API передаётся внутри `client`

### DIFF
--- a/index.js
+++ b/index.js
@@ -189,9 +189,8 @@ class NalogAPI {
   async addIncome ({ date = new Date(), name, quantity = 1, amount }) {
     const response = await this.call('income', {
       paymentType: 'CASH',
-      inn: null,
       ignoreMaxTotalIncomeRestriction: false,
-      client: { contactPhone: null, displayName: null, incomeType: 'FROM_INDIVIDUAL' },
+      client: { contactPhone: null, displayName: null, incomeType: 'FROM_INDIVIDUAL', inn: null },
 
       requestTime: this.dateToLocalISO(),
       operationTime: this.dateToLocalISO(date),


### PR DESCRIPTION
Может что-то изменили, inn клиента передаётся внутри объекта с данными клиента.

![image](https://user-images.githubusercontent.com/29860366/117089923-8cc2b100-ad5f-11eb-87fd-671f0b326131.png)